### PR TITLE
Add HTML tag escape

### DIFF
--- a/src/chrome/content/journal.js
+++ b/src/chrome/content/journal.js
@@ -15,6 +15,26 @@ Journal = {
         return newAuthorList;
     },
 
+    decodeHTMLEntities(text) {
+        if (typeof text !== 'string' || !text) return text;
+        
+        // 实体映射表（可扩展）
+        const entities = {
+            '&amp;': '&',
+            '&lt;': '<',
+            '&gt;': '>',
+            '&quot;': '"',
+            '&#39;': "'",
+            '&nbsp;': ' ',
+            // 添加其他常见实体...
+        };
+    
+        // 一次性替换所有已知实体
+        return text.replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (match, entity) => {
+            return entities[match] || match;
+        });
+    },
+
     generateDate (date) {
         if (!date) {
             return null;
@@ -59,14 +79,14 @@ Journal = {
                 }
             })
             .then(dataJson => {
-                var Title = Utilities.safeGetFromJson(dataJson, ["title"]);
+                var Title = this.decodeHTMLEntities(Utilities.safeGetFromJson(dataJson, ["title"]));
                 var Authors = this.generateAuthors(Utilities.safeGetFromJson(dataJson, ["author"]));
-                var Publication = Utilities.safeGetFromJson(dataJson, ["container-title"]);
+                var Publication = this.decodeHTMLEntities(Utilities.safeGetFromJson(dataJson, ["container-title"]));
                 var Volume = Utilities.safeGetFromJson(dataJson, ["volume"]);
                 var Issue = Utilities.safeGetFromJson(dataJson, ["issue"]);
                 var Pages = Utilities.safeGetFromJson(dataJson, ["page"]);
                 var PublishDate = this.generateDate(Utilities.safeGetFromJson(dataJson, ["published", "date-parts"]));
-                var JournalAbbr = Utilities.safeGetFromJson(dataJson, ["container-title-short"]);
+                var JournalAbbr = this.decodeHTMLEntities(Utilities.safeGetFromJson(dataJson, ["container-title-short"]));
                 var Language = Utilities.safeGetFromJson(dataJson, ["language"]);
                 return {
                             "Title": Title ? Title : "",


### PR DESCRIPTION
To address issue https://github.com/RoadToDream/ZotMeta/issues/10
My English is not good. The following content has been translated by a translation software
Due to the need for HTML tags such as'&', which usually appear in the journal name, only Journal.js was modified. The modified plugin has been packaged and tested without any issues
The speed test case is:
10.1016/j.jcp.2021.110296
10.1016/j.camwa.2022.12.008